### PR TITLE
fix: undefined is not propagated through HTTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gelatonetwork/web3-functions-sdk",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Gelato Automate Web3 Functions sdk",
   "repository": {
     "type": "git",

--- a/src/lib/Web3Function.ts
+++ b/src/lib/Web3Function.ts
@@ -36,6 +36,12 @@ export class Web3Function {
           const { result, ctxData } = await this._run(event.data.context);
 
           const difference = diff(prevStorage, ctxData.storage);
+          for (const key in difference) {
+            if (difference[key] === undefined) {
+              difference[key] = null;
+            }
+          }
+
           const state =
             Object.keys(difference).length === 0 ? "last" : "updated";
 


### PR DESCRIPTION
difference results undefined for removed objects and that is not
propagated through HTTP, thus prefer null for it